### PR TITLE
Don't clobber `type` when `format` is set

### DIFF
--- a/Phakefile.php
+++ b/Phakefile.php
@@ -54,7 +54,7 @@ task( 'endpoint-list', function( $app ){
 		'terms'              => array(
 			'plural_name'    => 'Terms',
 			'singular_name'  => 'Term',
-			'schema_route'   => '/wp-json/wp/v2/terms/categories/schema',
+			'schema_route'   => '/wp-json/wp/v2/terms/category/schema',
 			),
 		'users'              => array(
 			'plural_name'    => 'Users',
@@ -85,7 +85,7 @@ task( 'endpoint-list', function( $app ){
 					'context'       => ! empty( $args->context ) ? implode( $args->context, ', ' ) : '',
 					);
 				if ( ! empty( $args->format ) ) {
-					$property['type'] = $args->format;
+					$property['type'] .= ',' . $args->format;
 				}
 				$properties[] = $property;
 			}

--- a/_includes/routes/comments.md
+++ b/_includes/routes/comments.md
@@ -6,16 +6,16 @@
 | :------- | :--- | :---------- | :------ |
 | `id` | integer | Unique identifier for the object. | view, edit |
 | `author` | integer | The ID of the user object, if author was a user. | view, edit |
-| `author_email` | email | Email address for the object author. | edit |
+| `author_email` | string,email | Email address for the object author. | edit |
 | `author_ip` | string | IP address for the object author. | edit |
 | `author_name` | string | Display name for the object author. | view, edit |
-| `author_url` | uri | Url for the object author. | view, edit |
+| `author_url` | string,uri | Url for the object author. | view, edit |
 | `author_user_agent` | string | User agent for the object author. | edit |
 | `content` | object | The content for the object. | view, edit |
-| `date` | date-time | The date the object was published. | view, edit |
-| `date_gmt` | date-time | The date the object was published as GMT. | edit |
+| `date` | string,date-time | The date the object was published. | view, edit |
+| `date_gmt` | string,date-time | The date the object was published as GMT. | edit |
 | `karma` | integer | Karma for the object. | edit |
-| `link` | uri | URL to the object. | view, edit |
+| `link` | string,uri | URL to the object. | view, edit |
 | `parent` | integer | The ID for the parent of the object. | view, edit |
 | `post` | integer | The ID of the associated post object. | view, edit |
 | `status` | string | State of the object. | view, edit |

--- a/_includes/routes/media.md
+++ b/_includes/routes/media.md
@@ -4,13 +4,13 @@
 
 | Property | Type | Description | Context |
 | :------- | :--- | :---------- | :------ |
-| `date` | date-time | The date the object was published. | view, edit |
-| `date_gmt` | date-time | The date the object was published, as GMT. | edit |
+| `date` | string,date-time | The date the object was published. | view, edit |
+| `date_gmt` | string,date-time | The date the object was published, as GMT. | edit |
 | `guid` | object | The globally unique identifier for the object. | view, edit |
 | `id` | integer | Unique identifier for the object. | view, edit |
-| `link` | uri | URL to the object. | view, edit |
-| `modified` | date-time | The date the object was last modified. | view, edit |
-| `modified_gmt` | date-time | The date the object was last modified, as GMT. | view, edit |
+| `link` | string,uri | URL to the object. | view, edit |
+| `modified` | string,date-time | The date the object was last modified. | view, edit |
+| `modified_gmt` | string,date-time | The date the object was last modified, as GMT. | view, edit |
 | `password` | string | A password to protect access to the post. | edit |
 | `slug` | string | An alphanumeric identifier for the object unique to its type. | view, edit |
 | `status` | string | A named status for the object. | edit |
@@ -25,7 +25,7 @@
 | `media_type` | string | Type of attachment. | view, edit |
 | `media_details` | object | Details about the attachment file, specific to its type. | view, edit |
 | `post` | integer | The ID for the associated post of the attachment. | view, edit |
-| `source_url` | uri | URL to the original attachment file. | view, edit |
+| `source_url` | string,uri | URL to the original attachment file. | view, edit |
 
 ### List all Media
 

--- a/_includes/routes/pages.md
+++ b/_includes/routes/pages.md
@@ -4,13 +4,13 @@
 
 | Property | Type | Description | Context |
 | :------- | :--- | :---------- | :------ |
-| `date` | date-time | The date the object was published. | view, edit |
-| `date_gmt` | date-time | The date the object was published, as GMT. | edit |
+| `date` | string,date-time | The date the object was published. | view, edit |
+| `date_gmt` | string,date-time | The date the object was published, as GMT. | edit |
 | `guid` | object | The globally unique identifier for the object. | view, edit |
 | `id` | integer | Unique identifier for the object. | view, edit |
-| `link` | uri | URL to the object. | view, edit |
-| `modified` | date-time | The date the object was last modified. | view, edit |
-| `modified_gmt` | date-time | The date the object was last modified, as GMT. | view, edit |
+| `link` | string,uri | URL to the object. | view, edit |
+| `modified` | string,date-time | The date the object was last modified. | view, edit |
+| `modified_gmt` | string,date-time | The date the object was last modified, as GMT. | view, edit |
 | `password` | string | A password to protect access to the post. | edit |
 | `slug` | string | An alphanumeric identifier for the object unique to its type. | view, edit |
 | `status` | string | A named status for the object. | edit |

--- a/_includes/routes/post_revisions.md
+++ b/_includes/routes/post_revisions.md
@@ -5,12 +5,12 @@
 | Property | Type | Description | Context |
 | :------- | :--- | :---------- | :------ |
 | `author` | integer | The ID for the author of the object. | view |
-| `date` | date-time | The date the object was published. | view |
-| `date_gmt` | date-time | The date the object was published, as GMT. | view |
+| `date` | string,date-time | The date the object was published. | view |
+| `date_gmt` | string,date-time | The date the object was published, as GMT. | view |
 | `guid` | string | GUID for the object, as it exists in the database. | view |
 | `id` | integer | Unique identifier for the object. | view |
-| `modified` | date-time | The date the object was last modified. | view |
-| `modified_gmt` | date-time | The date the object was last modified, as GMT. | view |
+| `modified` | string,date-time | The date the object was last modified. | view |
+| `modified_gmt` | string,date-time | The date the object was last modified, as GMT. | view |
 | `parent` | integer | The ID for the parent of the object. | view |
 | `slug` | string | An alphanumeric identifier for the object unique to its type. | view |
 | `title` | string | Title for the object, as it exists in the database. | view |

--- a/_includes/routes/posts.md
+++ b/_includes/routes/posts.md
@@ -4,13 +4,13 @@
 
 | Property | Type | Description | Context |
 | :------- | :--- | :---------- | :------ |
-| `date` | date-time | The date the object was published. | view, edit |
-| `date_gmt` | date-time | The date the object was published, as GMT. | edit |
+| `date` | string,date-time | The date the object was published. | view, edit |
+| `date_gmt` | string,date-time | The date the object was published, as GMT. | edit |
 | `guid` | object | The globally unique identifier for the object. | view, edit |
 | `id` | integer | Unique identifier for the object. | view, edit |
-| `link` | uri | URL to the object. | view, edit |
-| `modified` | date-time | The date the object was last modified. | view, edit |
-| `modified_gmt` | date-time | The date the object was last modified, as GMT. | view, edit |
+| `link` | string,uri | URL to the object. | view, edit |
+| `modified` | string,date-time | The date the object was last modified. | view, edit |
+| `modified_gmt` | string,date-time | The date the object was last modified, as GMT. | view, edit |
 | `password` | string | A password to protect access to the post. | edit |
 | `slug` | string | An alphanumeric identifier for the object unique to its type. | view, edit |
 | `status` | string | A named status for the object. | edit |

--- a/_includes/routes/terms.md
+++ b/_includes/routes/terms.md
@@ -7,11 +7,11 @@
 | `id` | integer | Unique identifier for the object. | view |
 | `count` | integer | Number of published posts for the object. | view |
 | `description` | string | A human-readable description of the object. | view |
-| `link` | uri | URL to the object. | view |
+| `link` | string,uri | URL to the object. | view |
 | `name` | string | The title for the object. | view |
-| `parent` | integer | The ID for the parent of the object. | view |
 | `slug` | string | An alphanumeric identifier for the object unique to its type. | view |
 | `taxonomy` | string | Type attribution for the object. | view |
+| `parent` | integer | The ID for the parent of the object. | view |
 
 ### List all Terms
 

--- a/_includes/routes/users.md
+++ b/_includes/routes/users.md
@@ -4,21 +4,21 @@
 
 | Property | Type | Description | Context |
 | :------- | :--- | :---------- | :------ |
-| `avatar_url` | uri | Avatar URL for the object. | embed, view, edit |
+| `avatar_url` | string,uri | Avatar URL for the object. | embed, view, edit |
 | `capabilities` | object | All capabilities assigned to the user. | view, edit |
 | `description` | string | Description of the object. | embed, view, edit |
-| `email` | email | The email address for the object. | view, edit |
+| `email` | string,email | The email address for the object. | view, edit |
 | `extra_capabilities` | object | Any extra capabilities assigned to the user. | edit |
 | `first_name` | string | First name for the object. | embed, view, edit |
 | `id` | integer | Unique identifier for the object. | embed, view, edit |
 | `last_name` | string | Last name for the object. | embed, view, edit |
-| `link` | uri | Author URL to the object. | embed, view, edit |
+| `link` | string,uri | Author URL to the object. | embed, view, edit |
 | `name` | string | Display name for the object. | embed, view, edit |
 | `nickname` | string | The nickname for the object. | embed, view, edit |
 | `registered_date` | date-time | Registration date for the user. | view, edit |
 | `roles` | array | Roles assigned to the user. | view, edit |
 | `slug` | string | An alphanumeric identifier for the object unique to its type. | embed, view, edit |
-| `url` | uri | URL of the object. | embed, view, edit |
+| `url` | string,uri | URL of the object. | embed, view, edit |
 | `username` | string | Login name for the user. | edit |
 
 ### List all Users


### PR DESCRIPTION
Adding it as CSV seems more readable
