### PR TITLE
Update Authentication section on index.md

### DIFF
--- a/guide/authentication/index.md
+++ b/guide/authentication/index.md
@@ -33,7 +33,7 @@ POST data or in the query for GET requests), or via the `X-WP-Nonce` header.
 As an example, this is how the built-in Javascript client creates the nonce:
 
 ```php
-wp_localize_script( 'wp-api', 'WP_API_Settings', array( 'root' => esc_url_raw( rest_url('wp/v2') ), 'nonce' => wp_create_nonce( 'wp_rest' ) ) );
+wp_localize_script( 'wp-api', 'WP_API_Settings', array( 'root' => esc_url_raw( rest_url() ), 'nonce' => wp_create_nonce( 'wp_rest' ) ) );
 ```
 
 This is then used in the base model:

--- a/guide/authentication/index.md
+++ b/guide/authentication/index.md
@@ -33,7 +33,7 @@ POST data or in the query for GET requests), or via the `X-WP-Nonce` header.
 As an example, this is how the built-in Javascript client creates the nonce:
 
 ```php
-wp_localize_script( 'wp-api', 'WP_API_Settings', array( 'root' => esc_url_raw( get_json_url() ), 'nonce' => wp_create_nonce( 'wp_json' ) ) );
+wp_localize_script( 'wp-api', 'WP_API_Settings', array( 'root' => esc_url_raw( rest_url('wp/v2') ), 'nonce' => wp_create_nonce( 'wp_rest' ) ) );
 ```
 
 This is then used in the base model:


### PR DESCRIPTION
It looks like in v2 get_json_url() no longer exists, so I changed it to use rest_url(). It also looks like the nonce created in v2 was changed from wp_json to wp_rest. Using wp_json will return a 403 invalid nonce error.
