### PR TITLE
Increase contrast in sidebar links to achieve AA standard WCAG contra…

### DIFF
--- a/assets/styles/style.scss
+++ b/assets/styles/style.scss
@@ -93,7 +93,7 @@ header {
 	}
 
 	a {
-		color: rgba($fg-secondary, 0.6);
+		color: rgba($fg-secondary, 0.7);
 		text-decoration: none;
 	}
 }


### PR DESCRIPTION
…st ratio

The links in the sidebar were just under WCAG's [AA contrast standard](http://www.w3.org/TR/WCAG/#visual-audio-contrast), according to [this test](http://leaverou.github.io/contrast-ratio/#rgba%2851%2C51%2C51%2C%200.6%29-on-%23f7f7f7).

This commit bumps the contrast just over AA ([test](http://leaverou.github.io/contrast-ratio/#rgba%2851%2C51%2C51%2C%200.7%29-on-%23f7f7f7)).
