### PR TITLE
Fix prose page content alignment

### DIFF
--- a/assets/styles/style.scss
+++ b/assets/styles/style.scss
@@ -107,13 +107,14 @@ header {
 }
 
 .no-superbar {
+	$content-column-offset: floor( ( $superbar-column-width / 2 ) * ( $main-column-width / 12 ) );
 	#content {
 		@include grid-column($columns: $content-column-width);
-		@include grid-column($push: floor( $superbar-column-width / 2 ));
+		@include grid-column($push: $content-column-offset );
 	}
 
 	&.has-sticky #content {
-		@include grid-column($push: $sidebar-column-width + floor( $superbar-column-width / 2 ));
+		@include grid-column($push: $sidebar-column-width + $content-column-offset);
 	}
 }
 


### PR DESCRIPTION
Fixes #48.

Previously: the content was offset by half the width of the superbar.

Now: the content is offset by half the width of the superbar, multiplied by the proportion that the content column actually takes up.
