### PR TITLE
Correcting parameter for post to display comments in "What's changed"

### DIFF
--- a/changes-beta-1.md
+++ b/changes-beta-1.md
@@ -71,7 +71,7 @@ then we'd also love to know that. :)
 
 * **Changed**: Comments have been moved to a top-level endpoint at
   `/wp/v2/comments`. To fetch comments belonging to a post, use
-  `/wp/v2/comments?post_id=<id>`
+  `/wp/v2/comments?post=<id>`
 
 
 ## Future Changes


### PR DESCRIPTION
- Using the current param gets you a list of all the comments available.
- Changing from `post_id` to `post` get you the comments for the wanted post.
