### PR TITLE
Add hover anchor links to titles (https://github.com/WP-API/docs-v2/i…

### DIFF
--- a/_includes/anchor_links.html
+++ b/_includes/anchor_links.html
@@ -1,0 +1,45 @@
+<script type="text/javascript">
+  var anchorForId = function (id)
+  {
+    var anchor = document.createElement("a");
+
+    anchor.className = "header-link";
+    anchor.href      = "#" + id;
+    anchor.innerHTML = "<i class=\"fa fa-link\"></i>";
+    anchor.title     = "Permalink";
+
+    return anchor;
+  };
+
+  var linkifyAnchors = function (level, containingElement)
+  {
+    var headers = containingElement.getElementsByTagName("h" + level);
+
+    for (var h = 0; h < headers.length; h++)
+    {
+      var header = headers[h];
+
+      if (typeof header.id !== "undefined" && header.id !== "")
+      {
+        header.appendChild( anchorForId(header.id) );
+      }
+    }
+  };
+
+  document.onreadystatechange = function ()
+  {
+    if (this.readyState === "complete")
+    {
+      var contentBlock = document.getElementById("content");
+
+      if (!contentBlock) {
+        return;
+      }
+
+      for (var level = 2; level <= 6; level++)
+      {
+        linkifyAnchors(level, contentBlock);
+      }
+    }
+  };
+</script>

--- a/_includes/anchor_links.html
+++ b/_includes/anchor_links.html
@@ -1,45 +1,39 @@
 <script type="text/javascript">
-  var anchorForId = function (id)
-  {
-    var anchor = document.createElement("a");
+	var anchorForId = function( id ) {
+		var anchor = document.createElement( 'a' );
 
-    anchor.className = "header-link";
-    anchor.href      = "#" + id;
-    anchor.innerHTML = "<i class=\"fa fa-link\"></i>";
-    anchor.title     = "Permalink";
+		anchor.className = 'header-link';
+		anchor.href = '#' + id;
+		anchor.innerHTML = '<i class="link-icon"></i>';
+		anchor.title = 'Permalink';
 
-    return anchor;
-  };
+		return anchor;
+	};
 
-  var linkifyAnchors = function (level, containingElement)
-  {
-    var headers = containingElement.getElementsByTagName("h" + level);
+	var linkifyAnchors = function( level, containingElement ) {
+		var 	h,
+				headers = containingElement.getElementsByTagName( 'h' + level );
 
-    for (var h = 0; h < headers.length; h++)
-    {
-      var header = headers[h];
+		for( h = 0; h < headers.length; h++ ) {
+			var header = headers[ h ];
 
-      if (typeof header.id !== "undefined" && header.id !== "")
-      {
-        header.appendChild( anchorForId(header.id) );
-      }
-    }
-  };
+			if( 'undefined' !== typeof header.id && '' !==  header.id ) {
+				header.appendChild( anchorForId( header.id ) );
+			}
+		}
+	};
 
-  document.onreadystatechange = function ()
-  {
-    if (this.readyState === "complete")
-    {
-      var contentBlock = document.getElementById("content");
+	document.onreadystatechange = function() {
+		if( 'complete' === this.readyState  ) {
+			var contentBlock = document.getElementById( 'content' );
 
-      if (!contentBlock) {
-        return;
-      }
+			if( !contentBlock ) {
+				return;
+			}
 
-      for (var level = 2; level <= 6; level++)
-      {
-        linkifyAnchors(level, contentBlock);
-      }
-    }
-  };
+			for( var level = 2; level <= 6; level++ ) {
+				linkifyAnchors( level, contentBlock );
+			}
+		}
+	};
 </script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,8 +7,6 @@
 
 		<title>{% if page.include_title %}{{ page.title }} | {% endif %}{{site.title}}</title>
 
-		<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
-
 		<link rel="stylesheet" href="{{ site.baseurl }}assets/styles/style.css" />
 
 		<!-- Meta -->

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,6 +7,8 @@
 
 		<title>{% if page.include_title %}{{ page.title }} | {% endif %}{{site.title}}</title>
 
+		<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
+
 		<link rel="stylesheet" href="{{ site.baseurl }}assets/styles/style.css" />
 
 		<!-- Meta -->
@@ -47,5 +49,7 @@
 				s.parentNode.insertBefore(wf, s);
 			})();
 		</script>
+
+		{% include anchor_links.html %}
 	</body>
 </html>

--- a/assets/styles/style.scss
+++ b/assets/styles/style.scss
@@ -260,3 +260,18 @@ table.arguments, table.attributes {
 		margin-top: 0;
 	}
 }
+
+h1, h2, h3, h4, h5, h6 {
+	.header-link {
+		padding-left: 3px;
+		font-size: 85%;
+		color: $header-font-color;
+		display: none;
+	}
+
+	&:hover {
+		.header-link {
+			display: inline-block;
+		}
+	}
+}

--- a/assets/styles/style.scss
+++ b/assets/styles/style.scss
@@ -261,11 +261,17 @@ table.arguments, table.attributes {
 	}
 }
 
+.link-icon {
+	&:before {
+		content: "#";
+	}
+}
+
 h1, h2, h3, h4, h5, h6 {
 	.header-link {
-		padding-left: 3px;
-		font-size: 85%;
+		padding-left: 5px;
 		color: $header-font-color;
+		text-decoration: none;
 		display: none;
 	}
 


### PR DESCRIPTION
I based my solution on the Jekyll project's own implementation: https://george-hawkins.github.io/basic-gfm-jekyll/redcarpet-extensions.html#hover-anchors. It uses JS to add the links.

I also added in FontAwesome for the link icon. I can change this if there's some other standard we should use instead.
