### PR TITLE
changes function name to match the one in add_action()

### DIFF
--- a/extending/modifying/index.md
+++ b/extending/modifying/index.md
@@ -147,7 +147,7 @@ This example shows how to allow reading and writing of a post meta field. This w
  * Use arbitrary functions to add a field
  */
 add_action( 'rest_api_init', 'slug_register_something_random' );
-function slug_register_starship() {
+function slug_register_something_random() {
     register_rest_field( 'post',
         'something',
         array(


### PR DESCRIPTION
Changes function name from `slug_register_starship()` to `slug_register_something_random()`to match the function name in the `add_action`
