### PR TITLE
adds link to Documentation on Github

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -2,6 +2,7 @@
 	<h1><a href="{{ site.baseurl }}">WP REST API</a></h1>
 	<nav>
 		<ul>
+			<li><a href="https://github.com/WP-API/docs-v2">Documentation on GitHub</a></li>
 			<li><a href="https://github.com/WP-API/WP-API">Source on GitHub</a></li>
 			<li><a href="https://github.com/WP-API/WP-API/issues">Support</a></li>
 			<li><a class="button download" href="https://wordpress.org/plugins/rest-api/">Download</a></li>


### PR DESCRIPTION
Suggestion for link to the Documentation source on Github so people know they can contribute. Or maybe "Docs on Github" would be better (shorter)?
