### PR TITLE
Fix client-side JS API discovery example

### DIFF
--- a/guide/discovery/index.md
+++ b/guide/discovery/index.md
@@ -72,9 +72,9 @@ var $link = jQuery( 'link[rel="https://api.w.org/"]' );
 var api_root = $link.attr( 'href' );
 
 // Native method
-var links = document.getElementsByTagName('link');
-var link = Array.prototype.filter.apply( links, function ( item ) {
-	return ( item.rel === "https://api.w.org/" );
+var links = document.getElementsByTagName( 'link' );
+var link = Array.prototype.filter.call( links, function ( item ) {
+	return ( item.rel === 'https://api.w.org/' );
 } );
 var api_root = link[0].href;
 ```


### PR DESCRIPTION
[Function.prototype.apply](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/apply) takes arguments as an array or array-like object; Function.prototype.call allows those arguments to be passed in one by one, as is done here with the callback function. Making this change allows the client-side autodiscovery code to run properly.
