### PR TITLE
Fixed wrong naming of a variable in script example

### DIFF
--- a/guide/authentication/index.md
+++ b/guide/authentication/index.md
@@ -149,7 +149,7 @@ $headers = array (
 );
 $url = rest_url( 'wp/v2/posts/1' );
 
-$body = array(
+$data = array(
 	'title' => 'Hello Gaia' 
 );
 


### PR DESCRIPTION
In order to run properly the $body variable should be named $data.
$data is used in options array of wp_remote_post method.
