### PR TITLE
Adding AngularJS client

### DIFF
--- a/guide/plugins/index.md
+++ b/guide/plugins/index.md
@@ -82,8 +82,10 @@ Client libraries serve as a resource to easily access and utilize the WP REST AP
 * [Node.js client][]
 * [Golang client][]
 * [Ruby client][]
+* [AngularJS client][]
 
 [Backbone.js client]: https://github.com/WP-API/client-js
 [Node.js client]: https://github.com/kadamwhite/wordpress-rest-api
 [Golang client]: https://github.com/sogko/go-wordpress
 [Ruby client]: https://github.com/duncanjbrown/wp-api-client
+[AngularJS client]: https://github.com/shprink/wp-api-angularjs


### PR DESCRIPTION
Adding a complete lib that is used by https://github.com/shprink/wordpress-hybrid-client and can be used by any projects.
