### PR TITLE
Add link to relevant documentation

### DIFF
--- a/extending/adding/index.md
+++ b/extending/adding/index.md
@@ -240,7 +240,7 @@ The Controller Pattern
 
 The controller pattern is a best practice for working with complex endpoints with the API.
 
-It is recommended that you read "Extending Internal Classes" before reading this section. Doing so will familiarize you with the patterns used by the default routes, which is the best practice. While it is not required that the class you use to process your request extends the `WP_REST_Controller` class or a class that extends it, doing so allows you to inherit work done in those classes. In addition, you can rest assured that you're following best practices based on the controller methods you're using.
+It is recommended that you read ["Extending Internal Classes"](/extending/internal-classes/) before reading this section. Doing so will familiarize you with the patterns used by the default routes, which is the best practice. While it is not required that the class you use to process your request extends the `WP_REST_Controller` class or a class that extends it, doing so allows you to inherit work done in those classes. In addition, you can rest assured that you're following best practices based on the controller methods you're using.
 
 At their core, controllers are nothing more than a set of commonly named methods to match up with REST conventions, along with some handy helpers. Controllers register their routes in a `register_routes` method, respond to requests with `get_items`, `get_item`, `create_item`, `update_item` and `delete_item`, and have similarly named permission check methods. Following this pattern will ensure you don't miss any steps or functionality in your endpoints.
 


### PR DESCRIPTION
Added link to relevant documentation. For someone jumping in from links from outside resources (Google), the context and thus the proper link was not clear.
