### PR TITLE
Split reference into separate section

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,2 @@
-# A sample Gemfile
-source "https://rubygems.org"
-gem 'github-pages'
-gem 'pygments.rb'
+source 'https://rubygems.org'
+gem 'github-pages', group: :jekyll_plugins

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,11 +100,7 @@ GEM
       mini_portile2 (~> 2.0.0.rc2)
     octokit (4.2.0)
       sawyer (~> 0.6.0, >= 0.5.3)
-    posix-spawn (0.3.11)
     public_suffix (1.5.3)
-    pygments.rb (0.6.3)
-      posix-spawn (~> 0.3.6)
-      yajl-ruby (~> 1.2.0)
     rb-fsevent (0.9.7)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
@@ -122,14 +118,9 @@ GEM
       ethon (>= 0.8.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    yajl-ruby (1.2.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   github-pages
-  pygments.rb
-
-BUNDLED WITH
-   1.11.2

--- a/_config.yml
+++ b/_config.yml
@@ -29,4 +29,11 @@ defaults:
       path: "assets"
     values:
       layout: ""
+
+  -
+    scope:
+      path: "reference"
+    values:
+      layout: "reference"
+
 exclude: [vendor]

--- a/_config.yml
+++ b/_config.yml
@@ -6,6 +6,9 @@ baseurl: /
 encoding: utf-8
 highlighter: rouge
 markdown: kramdown
+kramdown:
+  input: GFM
+  hard_wrap: false
 redcarpet:
   extensions: ["no_intra_emphasis", "fenced_code_blocks", "autolink", "tables", "with_toc_data"]
 # markdown: kramdown

--- a/_config.yml
+++ b/_config.yml
@@ -35,5 +35,6 @@ defaults:
       path: "reference"
     values:
       layout: "reference"
+      has_superbar: Yes
 
 exclude: [vendor]

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -32,42 +32,7 @@
       page: guide/plugins/index.md
 
 - title: API Reference
-  items:
-    - title: Introduction
-      page: reference/index.md
-
-    - title: Posts
-      page: reference/posts/index.md
-
-    - title: Post Revisions
-      page: reference/posts/revisions.md
-
-    - title: Pages
-      page: reference/pages/index.md
-
-    - title: Media
-      page: reference/media/index.md
-
-    - title: Post Types
-      page: reference/types/index.md
-
-    - title: Post Statuses
-      page: reference/statuses/index.md
-
-    - title: Comments
-      page: reference/comments/index.md
-
-    - title: Taxonomies
-      page: reference/taxonomies/index.md
-
-    - title: Categories
-      page: reference/categories/index.md
-
-    - title: Tags
-      page: reference/tags/index.md
-
-    - title: Users
-      page: reference/users/index.md
+  page: reference/
 
 - title: Extending
   items:

--- a/_data/reference.yml
+++ b/_data/reference.yml
@@ -1,0 +1,39 @@
+- title: Introduction
+  items:
+    - title: Introduction
+      page: reference/index.md
+
+- title: Resources
+  items:
+    - title: Posts
+      page: reference/posts/index.md
+
+    - title: Post Revisions
+      page: reference/posts/revisions.md
+
+    - title: Pages
+      page: reference/pages/index.md
+
+    - title: Media
+      page: reference/media/index.md
+
+    - title: Post Types
+      page: reference/types/index.md
+
+    - title: Post Statuses
+      page: reference/statuses/index.md
+
+    - title: Comments
+      page: reference/comments/index.md
+
+    - title: Taxonomies
+      page: reference/taxonomies/index.md
+
+    - title: Categories
+      page: reference/categories/index.md
+
+    - title: Tags
+      page: reference/tags/index.md
+
+    - title: Users
+      page: reference/users/index.md

--- a/_data/reference.yml
+++ b/_data/reference.yml
@@ -3,6 +3,9 @@
     - title: Introduction
       page: reference/index.md
 
+    - title: Global Parameters
+      page: reference/global.md
+
 - title: Resources
   items:
     - title: Posts

--- a/_data/reference.yml
+++ b/_data/reference.yml
@@ -3,6 +3,9 @@
     - title: Introduction
       page: reference/index.md
 
+    - title: Linking and Embedding
+      page: reference/links.md
+
     - title: Global Parameters
       page: reference/global.md
 

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,0 +1,17 @@
+<script src="{{ site.baseurl }}assets/scripts/stick.js" async></script>
+<script type="text/javascript">
+	WebFontConfig = {
+		google: { families: [ 'Lora:400,400italic:latin', 'Istok+Web:400,400italic,700,700italic:latin' ] }
+	};
+	(function() {
+		var wf = document.createElement('script');
+		wf.src = ('https:' == document.location.protocol ? 'https' : 'http') +
+			'://ajax.googleapis.com/ajax/libs/webfont/1/webfont.js';
+		wf.type = 'text/javascript';
+		wf.async = 'true';
+		var s = document.getElementsByTagName('script')[0];
+		s.parentNode.insertBefore(wf, s);
+	})();
+</script>
+
+{% include anchor_links.html %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,0 +1,11 @@
+<meta charset="utf-8" />
+<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+<meta name="viewport" content="width=device-width" />
+
+<title>{% if page.include_title %}{{ page.title }} | {% endif %}{{site.title}}</title>
+
+<link rel="stylesheet" href="{{ site.baseurl }}assets/styles/style.css" />
+
+<!-- Meta -->
+<meta content="{{site.title}}" property="og:title" />
+<meta content="{{site.description}}" name="description" />

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -2,7 +2,8 @@
 	<h1><a href="{{ site.baseurl }}">WP REST API</a></h1>
 	<nav>
 		<ul>
-			<li><a href="https://github.com/WP-API/docs-v2">Documentation on GitHub</a></li>
+			<li><a href="{{ site.baseurl }}">Docs</a></li>
+			<li><a href="{{ site.baseurl }}reference/">Reference</a></li>
 			<li><a href="https://github.com/WP-API/WP-API">Source on GitHub</a></li>
 			<li><a href="https://github.com/WP-API/WP-API/issues">Support</a></li>
 			<li><a class="button download" href="https://wordpress.org/plugins/rest-api/">Download</a></li>

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -1,19 +1,28 @@
 <nav>
 
-	{% for section in site.data.navigation %}
+	{% for section in navigation %}
 
-		<h3>{{ section.title }}</h3>
-		<ul>
-			{% for item in section.items %}
+		{% if section.page %}
 
-				{% capture item_url %}/{{ item.page | remove: 'index.md' | replace: '.md', '.html' }}{% endcapture %}
+			{% capture section_url %}/{{ section.page | remove: 'index.md' | replace: '.md', '.html' }}{% endcapture %}
+			<h3><a href="{{ section_url }}">{{ section.title }}</a></h3>
 
-				<li {% if page.path == item.page %} class="active" {% endif %} >
-					<a href="{{ item_url }}">{{ item.title }}</a>
-				</li>
+		{% else %}
 
-			{% endfor %}
-		</ul>
+			<h3>{{ section.title }}</h3>
+			<ul>
+				{% for item in section.items %}
+
+					{% capture item_url %}/{{ item.page | remove: 'index.md' | replace: '.md', '.html' }}{% endcapture %}
+
+					<li {% if page.path == item.page %} class="active" {% endif %} >
+						<a href="{{ item_url }}">{{ item.title }}</a>
+					</li>
+
+				{% endfor %}
+			</ul>
+
+		{% endif %}
 
 	{% endfor %}
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,17 +1,7 @@
 <!doctype html>
 <html>
 	<head>
-		<meta charset="utf-8" />
-		<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
-		<meta name="viewport" content="width=device-width" />
-
-		<title>{% if page.include_title %}{{ page.title }} | {% endif %}{{site.title}}</title>
-
-		<link rel="stylesheet" href="{{ site.baseurl }}assets/styles/style.css" />
-
-		<!-- Meta -->
-		<meta content="{{site.title}}" property="og:title" />
-		<meta content="{{site.description}}" name="description" />
+		{% include head.html %}
 	</head>
 	<body class="{% if page.has_superbar %}has-superbar{% else %}no-superbar{% endif %}">
 		{% include header.html %}
@@ -32,22 +22,6 @@
 			{{ content }}
 		</section>
 
-		<script src="{{ site.baseurl }}assets/scripts/stick.js" async></script>
-		<script type="text/javascript">
-			WebFontConfig = {
-				google: { families: [ 'Lora:400,400italic:latin', 'Istok+Web:400,400italic,700,700italic:latin' ] }
-			};
-			(function() {
-				var wf = document.createElement('script');
-				wf.src = ('https:' == document.location.protocol ? 'https' : 'http') +
-					'://ajax.googleapis.com/ajax/libs/webfont/1/webfont.js';
-				wf.type = 'text/javascript';
-				wf.async = 'true';
-				var s = document.getElementsByTagName('script')[0];
-				s.parentNode.insertBefore(wf, s);
-			})();
-		</script>
-
-		{% include anchor_links.html %}
+		{% include footer.html %}
 	</body>
 </html>

--- a/_layouts/reference-static.html
+++ b/_layouts/reference-static.html
@@ -16,6 +16,8 @@
 
 			<section class="route">
 				<div class="primary">
+					<h1>{{ page.title }}</h1>
+
 					{{ content }}
 				</div>
 			</section>

--- a/_layouts/reference-static.html
+++ b/_layouts/reference-static.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html>
+	<head>
+		{% include head.html %}
+	</head>
+	<body class="has-superbar">
+		{% include header.html %}
+
+		<section id="sidebar">
+			{% assign navigation = site.data.reference %}
+			{% include sidebar.html %}
+		</section>
+
+		<section id="content">
+			<div class="background"><div class="primary"></div><div class="secondary"></div></div>
+
+			<section class="route">
+				<div class="primary">
+					{{ content }}
+				</div>
+			</section>
+		</section>
+
+		{% include footer.html %}
+	</body>
+</html>

--- a/_layouts/reference.html
+++ b/_layouts/reference.html
@@ -7,7 +7,7 @@
 		{% include header.html %}
 
 		<section id="sidebar">
-			{% assign navigation = site.data.navigation %}
+			{% assign navigation = site.data.reference %}
 			{% include sidebar.html %}
 		</section>
 

--- a/_layouts/reference.html
+++ b/_layouts/reference.html
@@ -3,7 +3,7 @@
 	<head>
 		{% include head.html %}
 	</head>
-	<body class="{% if page.has_superbar %}has-superbar{% else %}no-superbar{% endif %}">
+	<body class="has-superbar">
 		{% include header.html %}
 
 		<section id="sidebar">
@@ -12,13 +12,7 @@
 		</section>
 
 		<section id="content">
-			{% if page.has_superbar %}
-				<div class="background"><div class="primary"></div><div class="secondary"></div></div>
-			{% else %}
-				{% if page.include_title %}
-					<h1>{{ page.title }} <small style="float:right;"><a href="https://github.com/WP-API/docs-v2/edit/gh-pages/{{page.path}}">Edit Page</a></small></h1>
-				{% endif %}
-			{% endif %}
+			<div class="background"><div class="primary"></div><div class="secondary"></div></div>
 
 			{{ content }}
 		</section>

--- a/assets/styles/_config.scss
+++ b/assets/styles/_config.scss
@@ -25,8 +25,8 @@ $sidebar-column-width: 2;
 $main-column-width: 10;
 
 // Sub-layout
-$content-column-width: 8;
-$superbar-column-width: 4;
+$content-column-width: 6;
+$superbar-column-width: 6;
 
 // Configure Foundation
 // We turn everything default off, then turn back on as needed

--- a/assets/styles/_highlight-monokai.scss
+++ b/assets/styles/_highlight-monokai.scss
@@ -1,0 +1,65 @@
+.highlight {
+	.c { color: #75715e } /* Comment */
+	.err { color: #960050; background-color: #1e0010 } /* Error */
+	.k { color: #66d9ef } /* Keyword */
+	.l { color: #ae81ff } /* Literal */
+	.n { color: #f8f8f2 } /* Name */
+	.o { color: #f92672 } /* Operator */
+	.p { color: #f8f8f2 } /* Punctuation */
+	.cm { color: #75715e } /* Comment.Multiline */
+	.cp { color: #75715e } /* Comment.Preproc */
+	.c1 { color: #75715e } /* Comment.Single */
+	.cs { color: #75715e } /* Comment.Special */
+	.ge { font-style: italic } /* Generic.Emph */
+	.gs { font-weight: bold } /* Generic.Strong */
+	.kc { color: #66d9ef } /* Keyword.Constant */
+	.kd { color: #66d9ef } /* Keyword.Declaration */
+	.kn { color: #f92672 } /* Keyword.Namespace */
+	.kp { color: #66d9ef } /* Keyword.Pseudo */
+	.kr { color: #66d9ef } /* Keyword.Reserved */
+	.kt { color: #66d9ef } /* Keyword.Type */
+	.ld { color: #e6db74 } /* Literal.Date */
+	.m { color: #ae81ff } /* Literal.Number */
+	.s { color: #e6db74 } /* Literal.String */
+	.na { color: #a6e22e } /* Name.Attribute */
+	.nb { color: #f8f8f2 } /* Name.Builtin */
+	.nc { color: #a6e22e } /* Name.Class */
+	.no { color: #66d9ef } /* Name.Constant */
+	.nd { color: #a6e22e } /* Name.Decorator */
+	.ni { color: #f8f8f2 } /* Name.Entity */
+	.ne { color: #a6e22e } /* Name.Exception */
+	.nf { color: #a6e22e } /* Name.Function */
+	.nl { color: #f8f8f2 } /* Name.Label */
+	.nn { color: #f8f8f2 } /* Name.Namespace */
+	.nx { color: #a6e22e } /* Name.Other */
+	.py { color: #f8f8f2 } /* Name.Property */
+	.nt { color: #f92672 } /* Name.Tag */
+	.nv { color: #f8f8f2 } /* Name.Variable */
+	.ow { color: #f92672 } /* Operator.Word */
+	.w { color: #f8f8f2 } /* Text.Whitespace */
+	.mf { color: #ae81ff } /* Literal.Number.Float */
+	.mh { color: #ae81ff } /* Literal.Number.Hex */
+	.mi { color: #ae81ff } /* Literal.Number.Integer */
+	.mo { color: #ae81ff } /* Literal.Number.Oct */
+	.sb { color: #e6db74 } /* Literal.String.Backtick */
+	.sc { color: #e6db74 } /* Literal.String.Char */
+	.sd { color: #e6db74 } /* Literal.String.Doc */
+	.s2 { color: #e6db74 } /* Literal.String.Double */
+	.se { color: #ae81ff } /* Literal.String.Escape */
+	.sh { color: #e6db74 } /* Literal.String.Heredoc */
+	.si { color: #e6db74 } /* Literal.String.Interpol */
+	.sx { color: #e6db74 } /* Literal.String.Other */
+	.sr { color: #e6db74 } /* Literal.String.Regex */
+	.s1 { color: #e6db74 } /* Literal.String.Single */
+	.ss { color: #e6db74 } /* Literal.String.Symbol */
+	.bp { color: #f8f8f2 } /* Name.Builtin.Pseudo */
+	.vc { color: #f8f8f2 } /* Name.Variable.Class */
+	.vg { color: #f8f8f2 } /* Name.Variable.Global */
+	.vi { color: #f8f8f2 } /* Name.Variable.Instance */
+	.il { color: #ae81ff } /* Literal.Number.Integer.Long */
+
+	.gh { } /* Generic Heading & Diff Header */
+	.gu { color: #75715e; } /* Generic.Subheading & Diff Unified/Comment? */
+	.gd { color: #f92672; } /* Generic.Deleted & Diff Deleted */
+	.gi { color: #a6e22e; } /* Generic.Inserted & Diff Inserted */
+}

--- a/assets/styles/style.scss
+++ b/assets/styles/style.scss
@@ -267,6 +267,7 @@ pre {
 .route {
 	@include grid-row($behavior: nest-collapse);
 	position: relative;
+	margin-bottom: 1rem;
 }
 
 table.arguments, table.attributes {

--- a/assets/styles/style.scss
+++ b/assets/styles/style.scss
@@ -176,18 +176,26 @@ pre {
 	}
 }
 
+.secondary {
+	@import "highlight-monokai";
+}
+
 .secondary pre {
 	background: rgba($fg-superbar, 0.04);
+	tab-size: 2;
+	-moz-tab-size: 2;
+	-o-tab-size: 2;
 }
 
 .secondary code {
 	background: rgba(0,0,0,.18);
-	margin: 0 -15px;
-	padding: 15px;
 	display: inline-block;
 	word-wrap: break-word;
-	width: 109%;
 	color: #bbb;
+}
+
+.secondary pre code {
+	background: transparent;
 }
 
 .note {

--- a/assets/styles/style.scss
+++ b/assets/styles/style.scss
@@ -74,6 +74,14 @@ header {
 			top: 1.2em;
 			bottom: 0.5em;
 		}
+
+		a {
+			color: inherit;
+
+			&:after {
+				content: " \002192";
+			}
+		}
 	}
 
 	nav ul {

--- a/assets/styles/style.scss
+++ b/assets/styles/style.scss
@@ -272,10 +272,22 @@ pre {
 
 table.arguments, table.attributes {
 	width: 100%;
+	border: none;
+	border-collapse: collapse;
 
 	p {
 		margin: .5rem 0;
 	}
+
+	td {
+		border: none;
+		border-bottom: 1px solid #e0e0e0;
+	}
+
+	tr:last-of-type td {
+		border-bottom: none;
+	}
+
 	td:first-child {
 		width: 33%;
 
@@ -298,9 +310,17 @@ table.arguments, table.attributes {
 	}
 
 	.read-only {
-		color: #666;
+		color: #aaa;
 		font-size: 13px;
 		margin-top: 0;
+		border: 1px solid #ddd;
+		display: inline-block;
+		padding: 0.2em 0.3em;
+		border-radius: 6px;
+	}
+
+	code a {
+		text-decoration: none;
 	}
 }
 

--- a/reference/global.md
+++ b/reference/global.md
@@ -1,0 +1,113 @@
+---
+page: global
+title: Global Parameters
+layout: reference-static
+---
+
+The API includes a number of global parameters (also called "meta-parameters") which control how the API handles the request/response handling. These operate at a layer above the actual resources themselves, and are available on all resources.
+
+## `_jsonp`
+
+The API natively supports [JSONP][] responses to allow cross-domain requests for legacy browsers and clients. This parameter takes a JavaScript callback function which will be prepended to the data. This URL can then be loaded via a `<script>` tag.
+
+For example:
+
+```html
+<script>
+function receiveData( data ) {
+	// Do something with the data here.
+	// For demonstration purposes, we'll simply log it.
+	console.log( data );
+}
+</script>
+<script src="http://demo.wp-api.org/wp-json/?_jsonp=receiveData"></script>
+```
+
+The callback function can contain any alphanumeric, `_` (underscore), or `.` (period) character. Callbacks which contain invalid characters will receive a HTTP 400 error response, and the callback will not be called.
+
+<div class="note" markdown="1">
+Modern browsers can use [Cross-Origin Resource Sharing (CORS)][CORS] preflight requests for cross-domain requests, but JSONP can be used to ensure support with all browsers.
+
+* [Browser Support](http://caniuse.com/#feat=cors)
+* [MDN Article on CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS)
+</div>
+
+[CORS]: https://en.wikipedia.org/wiki/Cross-origin_resource_sharing
+[JSONP]: https://en.wikipedia.org/wiki/JSONP
+
+
+## `_method` (or `X-HTTP-Method-Override` header)
+
+Some servers and clients cannot correctly process some HTTP methods that the API makes use of. For example, all deletion requests on resources use the `DELETE` method, but some clients do not provide the ability to send this method.
+
+To ensure compatibility with these servers and clients, the API supports a method override. This can be passed either via a `_method` parameter or the `X-HTTP-Method-Override` header, with the value set to the HTTP method to use.
+
+For example, a `POST` to `/wp-json/wp/v2/posts/42?_method=DELETE` would be translated to a `DELETE` to the `wp/v2/posts/42` route.
+
+Similarly, the following POST request would become a DELETE:
+
+```
+POST /wp-json/wp/v2/posts/42 HTTP/1.1
+Host: example.com
+X-HTTP-Method-Override: DELETE
+```
+
+<div class="note warning" markdown="1">
+Clients should only ever send a method override parameter or header with POST requests. Using the method override with GET requests may cause the request to be incorrectly cached.
+</div>
+
+
+## `_envelope`
+
+Similarly to `_method`, some servers, clients, and proxies do not support accessing the full response data. The API supports passing an `_envelope` parameter, which sends all response data in the body, including headers and status code.
+
+Envelope mode is enabled if the `_envelope` parameter is passed in the query string (GET parameter). This parameter does not require a value (i.e. `?_envelope` is valid), but can be passed "1" as a value if required by a client library.
+
+<div class="note" markdown="1">
+For future compatibility, other values should not be passed.
+</div>
+
+Enveloped responses include a "fake" HTTP 200 response code with no additional headers (apart from Content-Type) that should ensure the response correctly passes through intermediaries.
+
+For example, given the following response to a `GET` to `wp/v2/users/me`:
+
+```
+HTTP/1.1 302 Found
+Location: http://example.com/wp-json/wp/v2/users/42
+
+{
+	"id": 42,
+	...
+}
+```
+
+The equivalent enveloped response (with a `GET` to `wp/v2/users/me?_envelope`) would be:
+
+```
+HTTP/1.1 200 OK
+
+{
+	"status": 302,
+	"headers": {
+		"Location": "http://example.com/wp-json/wp/v2/users/42"
+	},
+	"body": {
+		"id": 42
+	}
+}
+```
+
+
+## `_embed`
+
+Most resources include links to related resources. For example, a post can link to the parent post, or to comments on the post. To reduce the number of HTTP requests required, clients may wish to fetch a resource as well as the linked resources. The `_embed` parameter indicates to the server that the response should include these embedded resources.
+
+Embed mode is enabled if the `_embed` parameter is passed in the query string (GET parameter). This parameter does not require a value (i.e. `?_embed` is valid), however can be passed "1" as a value if required by a client library.
+
+<div class="note" markdown="1">
+For future compatibility, other values should not be passed.
+</div>
+
+Resources in embed mode will contain an additional `_embedded` key next to the `_links` key containing the linked resources. Only links with the `embeddable` parameter set to `true` will be embedded.
+
+For more about linking and embedding, see the [Linking and Embedding page](links.html).

--- a/reference/global.md
+++ b/reference/global.md
@@ -1,27 +1,22 @@
 ---
 page: global
 title: Global Parameters
-layout: reference-static
+layout: reference
 ---
 
-The API includes a number of global parameters (also called "meta-parameters") which control how the API handles the request/response handling. These operate at a layer above the actual resources themselves, and are available on all resources.
+<section class="route">
+<div class="primary" markdown="1">
+<h1>{{ page.title }}</h1>
 
+The API includes a number of global parameters (also called "meta-parameters") which control how the API handles the request/response handling. These operate at a layer above the actual resources themselves, and are available on all resources.
+</div>
+</section>
+
+<section class="route">
+<div class="primary" markdown="1">
 ## `_jsonp`
 
 The API natively supports [JSONP][] responses to allow cross-domain requests for legacy browsers and clients. This parameter takes a JavaScript callback function which will be prepended to the data. This URL can then be loaded via a `<script>` tag.
-
-For example:
-
-```html
-<script>
-function receiveData( data ) {
-	// Do something with the data here.
-	// For demonstration purposes, we'll simply log it.
-	console.log( data );
-}
-</script>
-<script src="http://demo.wp-api.org/wp-json/?_jsonp=receiveData"></script>
-```
 
 The callback function can contain any alphanumeric, `_` (underscore), or `.` (period) character. Callbacks which contain invalid characters will receive a HTTP 400 error response, and the callback will not be called.
 
@@ -35,14 +30,38 @@ Modern browsers can use [Cross-Origin Resource Sharing (CORS)][CORS] preflight r
 [CORS]: https://en.wikipedia.org/wiki/Cross-origin_resource_sharing
 [JSONP]: https://en.wikipedia.org/wiki/JSONP
 
+</div>
+<div class="secondary" markdown="1">
 
+For example:
+
+```html
+<script>
+function receiveData( data ) {
+	// Do something with the data here.
+	// For demonstration purposes, we'll simply log it.
+	console.log( data );
+}
+</script>
+<script src="http://demo.wp-api.org/wp-json/?_jsonp=receiveData"></script>
+```
+</div>
+</section>
+
+<section class="route">
+<div class="primary" markdown="1">
 ## `_method` (or `X-HTTP-Method-Override` header)
 
 Some servers and clients cannot correctly process some HTTP methods that the API makes use of. For example, all deletion requests on resources use the `DELETE` method, but some clients do not provide the ability to send this method.
 
 To ensure compatibility with these servers and clients, the API supports a method override. This can be passed either via a `_method` parameter or the `X-HTTP-Method-Override` header, with the value set to the HTTP method to use.
 
-For example, a `POST` to `/wp-json/wp/v2/posts/42?_method=DELETE` would be translated to a `DELETE` to the `wp/v2/posts/42` route.
+<div class="note warning" markdown="1">
+Clients should only ever send a method override parameter or header with POST requests. Using the method override with GET requests may cause the request to be incorrectly cached.
+</div>
+</div>
+<div class="secondary" markdown="1">
+A `POST` to `/wp-json/wp/v2/posts/42?_method=DELETE` would be translated to a `DELETE` to the `wp/v2/posts/42` route.
 
 Similarly, the following POST request would become a DELETE:
 
@@ -51,12 +70,12 @@ POST /wp-json/wp/v2/posts/42 HTTP/1.1
 Host: example.com
 X-HTTP-Method-Override: DELETE
 ```
-
-<div class="note warning" markdown="1">
-Clients should only ever send a method override parameter or header with POST requests. Using the method override with GET requests may cause the request to be incorrectly cached.
 </div>
+</section>
 
 
+<section class="route">
+<div class="primary" markdown="1">
 ## `_envelope`
 
 Similarly to `_method`, some servers, clients, and proxies do not support accessing the full response data. The API supports passing an `_envelope` parameter, which sends all response data in the body, including headers and status code.
@@ -68,7 +87,9 @@ For future compatibility, other values should not be passed.
 </div>
 
 Enveloped responses include a "fake" HTTP 200 response code with no additional headers (apart from Content-Type) that should ensure the response correctly passes through intermediaries.
+</div>
 
+<div class="secondary" markdown="1">
 For example, given the following response to a `GET` to `wp/v2/users/me`:
 
 ```
@@ -96,8 +117,11 @@ HTTP/1.1 200 OK
 	}
 }
 ```
+</div>
+</section>
 
-
+<section class="route">
+<div class="primary" markdown="1">
 ## `_embed`
 
 Most resources include links to related resources. For example, a post can link to the parent post, or to comments on the post. To reduce the number of HTTP requests required, clients may wish to fetch a resource as well as the linked resources. The `_embed` parameter indicates to the server that the response should include these embedded resources.
@@ -111,3 +135,5 @@ For future compatibility, other values should not be passed.
 Resources in embed mode will contain an additional `_embedded` key next to the `_links` key containing the linked resources. Only links with the `embeddable` parameter set to `true` will be embedded.
 
 For more about linking and embedding, see the [Linking and Embedding page](links.html).
+</div>
+</section>

--- a/reference/global.md
+++ b/reference/global.md
@@ -43,7 +43,7 @@ function receiveData( data ) {
 	console.log( data );
 }
 </script>
-<script src="http://demo.wp-api.org/wp-json/?_jsonp=receiveData"></script>
+<script src="https://demo.wp-api.org/wp-json/?_jsonp=receiveData"></script>
 ```
 </div>
 </section>

--- a/reference/index.md
+++ b/reference/index.md
@@ -4,7 +4,21 @@ title: API Reference
 layout: reference-static
 ---
 
-The API is organized around [REST][]. Our API is designed to have predictable, resource-oriented URLs and to use HTTP response codes to indicate API errors. We use built-in HTTP features, like HTTP authentication and HTTP verbs, which can be understood by off-the-shelf HTTP clients, and we support cross-origin resource sharing to allow you to interact securely with our API from a client-side web application. JSON will be returned in all responses from the API, including errors.
+Welcome to the API reference for the WordPress REST API! It's great to have you here.
 
+The API is organized around [REST][]. Our API is designed to have predictable, resource-oriented URLs and to use HTTP response codes to indicate API errors. We use built-in HTTP features, like HTTP authentication and HTTP verbs, which can be understood by off-the-shelf HTTP clients, and we support cross-origin resource sharing to allow you to interact securely with the API from a client-side web application.
+
+The API uses JSON exclusively as the request and response format, including error responses. It also uses the [HAL standard][] for linking, and is fully discoverable via hyperlinks in the responses.
+
+The API provides public data accessable to any client anonymously, as well as private data only available after [authentication](/guide/authentication/). Most content management actions can be performed over the REST API, allowing you to build alternative dashboards for a site, enhance your plugins with more responsive management tools, as well as building single-page applications for a site.
+
+This API reference provides information on what's available through the API, however common usage patterns and guides are available as part of the [general documentation](/).
+
+Unlike many other REST APIs, the WordPress REST API is distributed and available individually on each site that supports it. This means there is no singular API root or base to contact; instead, we have [a discovery process](/guide/discovery/) that allows interacting with sites without prior contact. The API also exposes self-documentation at the index endpoint, or via an `OPTIONS` request to any endpoint, allowing human- or machine-discovery of endpoint capabilities.
+
+We provide a [demo installation][demo] of the API for testing purposes at `https://demo.wp-api.org/wp-json/`; this site supports autodiscovery, and provides read-only demo data. (This documentation site is generated using the self-documentation from the demo site.)
+
+[demo]: https://demo.wp-api.org/
+[HAL standard]: http://stateless.co/hal_specification.html
 [REST]: http://en.wikipedia.org/wiki/Representational_state_transfer
 

--- a/reference/index.md
+++ b/reference/index.md
@@ -1,18 +1,12 @@
 ---
 page: introduction
 title: API Reference
-has_superbar: Yes
+layout: reference-static
 ---
 
-{% capture intro %}
 # API Reference
 
 The API is organized around [REST][]. Our API is designed to have predictable, resource-oriented URLs and to use HTTP response codes to indicate API errors. We use built-in HTTP features, like HTTP authentication and HTTP verbs, which can be understood by off-the-shelf HTTP clients, and we support cross-origin resource sharing to allow you to interact securely with our API from a client-side web application. JSON will be returned in all responses from the API, including errors.
 
 [REST]: http://en.wikipedia.org/wiki/Representational_state_transfer
-{% endcapture %}
-
-<section class="route">
-	<div class="primary">{{ intro | markdownify }}</div>
-</section>
 

--- a/reference/index.md
+++ b/reference/index.md
@@ -4,8 +4,6 @@ title: API Reference
 layout: reference-static
 ---
 
-# API Reference
-
 The API is organized around [REST][]. Our API is designed to have predictable, resource-oriented URLs and to use HTTP response codes to indicate API errors. We use built-in HTTP features, like HTTP authentication and HTTP verbs, which can be understood by off-the-shelf HTTP clients, and we support cross-origin resource sharing to allow you to interact securely with our API from a client-side web application. JSON will be returned in all responses from the API, including errors.
 
 [REST]: http://en.wikipedia.org/wiki/Representational_state_transfer

--- a/reference/links.md
+++ b/reference/links.md
@@ -1,0 +1,96 @@
+---
+page: links
+title: Linking and Embedding
+layout: reference
+---
+
+<section class="route">
+<div class="primary" markdown="1">
+
+# {{ page.title }}
+
+The WP REST API incorporates hyperlinking throughout the API to allow discoverability and browsability. We use the [HAL standard][] for linking, as well as embedding other resources.
+
+Links are provided in the `_links` property of the response object, which contains a map of "relation" to a list of the links themselves. The relation specifies how the linked resource relates to the primary resource you're accessing. The relation is either a [standardised relation][iana-link-relation], a URI relation (like `https://api.w.org/term`) or a Compact URI relation (like `wp:term`). (Compact URI relations can be normalised to full URI relations to ensure full compatibility if required.) This is similar to HTML `<link>` tags, or `<a rel="">` links.
+
+The links are an object containing a `href` property with an absolute URL to the resource, as well as other optional properties. These include content types, disambiguation information, and data on actions that can be taken with the link.
+
+For collection responses (those that return a list of objects rather than a top-level object), each item contains links, and the top-level response includes links via the `Link` header instead.
+
+<div class="note" markdown="1">
+If your client library does not allow accessing headers, you can use the [`_envelope`](global.html#envelope) parameter to include the headers as body data instead.
+</div>
+
+[iana-link-relation]: http://www.iana.org/assignments/link-relations/link-relations.xhtml#link-relations-1
+[HAL standard]: http://stateless.co/hal_specification.html
+
+</div>
+<div class="secondary" markdown="1">
+
+### Example Response
+
+A typical single post request (`/wp/v2/posts/42`):
+
+```json
+{
+	"id": 42,
+	"_links": {
+		"collection": [
+			{
+				"href": "https://demo.wp-api.org/wp-json/wp/v2/posts"
+			}
+		],
+		"author": [
+			{
+				"href": "https://demo.wp-api.org/wp-json/wp/v2/users/1",
+				"embeddable": true
+			}
+		]
+	}
+}
+```
+
+</div>
+</section>
+
+<section class="route">
+<div class="primary" markdown="1">
+
+### Embedding
+
+Optionally, some linked resources may be included in the response to reduce the number of HTTP requests required. These resources are "embedded" into the main response.
+
+Embedding is triggered by setting the [`_embed` query parameter](global.html#embed) on the request. This will then include embedded resources under the `_embedded` key adjacent to the `_links` key. The layout of this object mirrors the `_links` object, but includes the embedded resource in place of the link properties.
+
+Only links with the `embedded` flag set to `true` can be embedded, and `_embed` will cause all embeddable links to be embedded. Only relations containing embedded responses are included in `_embedded`, however relations with mixed embeddable and unembeddable links will contain dummy responses for the unembeddable links to ensure numeric indexes match those in `_links`.
+
+</div>
+<div class="secondary" markdown="1">
+
+```json
+{
+	"id": 42,
+	"_links": {
+		"collection": [
+			{
+				"href": "https://demo.wp-api.org/wp-json/wp/v2/posts"
+			}
+		],
+		"author": [
+			{
+				"href": "https://demo.wp-api.org/wp-json/wp/v2/users/1",
+				"embeddable": true
+			}
+		]
+	},
+	"_embedded": {
+		"author": {
+			"id": 1,
+			"name": "admin",
+			"description": "Site administrator"
+		}
+	}
+}
+```
+</div>
+</section>


### PR DESCRIPTION
This cleans up the reference, separates it from the prose guides (which cleans up the nav), and includes some new never-before-seen content as well.

The separation here is that the reference describes what the API does, whereas the guides explain how to use it. It's a bit blurry, and that's OK.
