### PR TITLE
`slug_update_spaceship` would not update meta if `$value` evaluates to `false`

### DIFF
--- a/extending/modifying/index.md
+++ b/extending/modifying/index.md
@@ -128,7 +128,7 @@ function slug_get_spaceship( $object, $field_name, $request ) {
  * @return bool|int
  */
 function slug_update_spaceship( $value, $object, $field_name ) {
-    if ( ! $value || ! is_string( $value ) ) {
+    if ( ! isset( $value ) || ! is_string( $value ) || strlen( $value ) < 1 ) {
         return;
     }
 


### PR DESCRIPTION
If you check for `! $value` in the validation in the example callback method `slug_update_spaceship`, a string value of `'0'` (or anything else that PHP evaluates to false) will be ignored and that post meta field will not be updated.

Since `'0'` might be a desired post meta value, I propose changing the validation on this line to instead check `isset` and ensure the string's length is >0.
