### PR TITLE
Back-link to legacy V1 documentation site

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -26,4 +26,8 @@
 
 	{% endfor %}
 
+	<h3>
+		<a href="http://wp-api.org/index-deprecated.html">Version 1 Docs</a>
+	</h3>
+
 </nav>

--- a/assets/styles/style.scss
+++ b/assets/styles/style.scss
@@ -26,6 +26,10 @@ header {
 	a {
 		color: inherit;
 		text-decoration: none;
+
+		&:hover {
+			text-decoration: underline;
+		}
 	}
 
 	nav {
@@ -42,6 +46,10 @@ header {
 		margin: {
 			top: -$button-tny;
 			bottom: -$button-tny;
+		}
+
+		&:hover {
+			text-decoration: none;
 		}
 
 		@include button-size($padding:$button-tny);
@@ -110,6 +118,10 @@ header {
 	a {
 		color: rgba($fg-secondary, 0.7);
 		text-decoration: none;
+
+		&:hover {
+			text-decoration: underline;
+		}
 	}
 }
 
@@ -232,6 +244,10 @@ pre {
 	.status {
 		a {
 			text-decoration: none;
+
+			&:hover {
+				text-decoration: underline;
+			}
 		}
 	}
 }

--- a/extending/custom-content-types/index.md
+++ b/extending/custom-content-types/index.md
@@ -158,3 +158,7 @@ Here is an example of how to add REST API support to an already registered custo
 ```
 
 If you are having trouble implementing either of these examples, be sure that you are adding these hooks with a sufficiently high priority. If the callback functions run before the post type or taxonomy is registered, then the `isset` check will prevent an error, but the support will not be added.
+
+### Custom Link Relationships
+
+Taxonomies & custom post types have a built-in association within WordPress, but what if you want to establish a link between two custom post types? This is not supported formally within WordPress itself, but we can create our own connections between arbitrary content types using the `_link` relation.

--- a/index.md
+++ b/index.md
@@ -22,6 +22,13 @@ include_title: No
 		</a>
 	</p>
 
+	<p class="status">
+		<em>Using Version 1 of the API?</em>
+		<a href="http://wp-api.org/index-deprecated.html">
+			View the legacy documentation
+		</a>
+	</p>
+
 </div>
 
 About


### PR DESCRIPTION
On landing page:

![image](https://cloud.githubusercontent.com/assets/442115/18793412/a6ac5ccc-8188-11e6-95df-863f24857e22.png)

In sidebar:

![image](https://cloud.githubusercontent.com/assets/442115/18793379/7cc49a96-8188-11e6-9504-864e12b9d95d.png)
