### PR TITLE
Migration Example minor update

### DIFF
--- a/changes-beta-1.md
+++ b/changes-beta-1.md
@@ -122,7 +122,7 @@ headers. There are a few key changes we need to make here:
   single `WP_REST_Request` object
 
 * Route registration now takes place via a helper function rather than directly
-  via the filter
+  via the filter, and includes specification for arguments
 
 Here's what the new API looks like:
 
@@ -154,7 +154,6 @@ function tsla_add_horn_honks( WP_REST_Request $request ) {
 }
 ```
 
-You'll notice that a lot of this looks pretty much the same! We've moved our
-validation check out, and renamed a few things, but otherwise our callback is
-mostly the same. The route registration has expanded to use the function for
-registration instead.
+You'll notice that this looks pretty similar! We've moved argument preprocessing
+up to route registration, added a new class to receive data and renamed a few
+things, but the rest of our code is unchanged.

--- a/changes-beta-1.md
+++ b/changes-beta-1.md
@@ -137,6 +137,7 @@ function tsla_register_routes( $routes ) {
         'args'     => array(
             'honks' => array(
                 'required'          => false,
+                'default'           => 1,
                 'validate_callback' => 'is_numeric',
             ),
         )


### PR DESCRIPTION
In the migration example, the "before" includes a default value that we should really include in the after.

I've also tried to update the text around it to match in a separate commit (bc4d0e8), because it's more subjective. I'm fine with changing or dropping those textual changes.


