### PR TITLE
Add settings schema

### DIFF
--- a/_data/reference.yml
+++ b/_data/reference.yml
@@ -43,3 +43,6 @@
 
     - title: Users
       page: reference/users/index.md
+
+    - title: Settings
+      page: reference/settings/index.md

--- a/_includes/reference-parts/update-settings.html
+++ b/_includes/reference-parts/update-settings.html
@@ -1,0 +1,7 @@
+<section class="route">
+	<div class="primary">
+		<h2>Update a {{ page.resource }}</h2>
+		{% assign args = include.route.endpoints[1].args %}
+		{% include reference-parts/args-list.html args=args link=true %}
+	</div>
+</section>

--- a/reference/settings/index.md
+++ b/reference/settings/index.md
@@ -1,0 +1,20 @@
+---
+title: Users API Reference
+has_superbar: Yes
+route_path: wp-json/wp/v2/settings
+resource: Setting
+---
+
+<section class="route">
+	<div class="primary">
+		{% include reference-parts/schema.html schema=site.data.settings.schema %}
+	</div>
+	<div class="secondary">
+		<h3>Example Request</h3>
+
+		<code>$ curl -X OPTIONS -i http://demo.wp-api.org/wp-json{{ site.data.settings.routes['/wp/v2/settings'].nicename }}</code>
+	</div>
+</section>
+
+{% assign route=site.data.settings.routes['/wp/v2/settings'] %}
+{% include reference-parts/update-settings.html route=route %}


### PR DESCRIPTION
Fixes #196.  Adds a page for the settings endpoint covering the schema and endpoint arguments.  The views did not fit this endpoint well and were breaking so a new view was created to cover this.