### PR TITLE
Initial support for setting canonical URLs per page

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -9,3 +9,6 @@
 <!-- Meta -->
 <meta content="{{site.title}}" property="og:title" />
 <meta content="{{site.description}}" name="description" />
+{% if page.canonical_url != nil %}
+<link rel="canonical" href="{{ page.canonical_url }}"/>
+{% endif %}

--- a/extending/adding/index.md
+++ b/extending/adding/index.md
@@ -1,5 +1,6 @@
 ---
 title: Adding Custom Endpoints
+canonical_url: https://developer.wordpress.org/rest-api/extending-the-rest-api/adding-custom-endpoints/
 ---
 
 <div class="warning">


### PR DESCRIPTION
...& add a target for a test page (extending/adding).

See: https://twitter.com/alapapa/status/1093983402783580160

Solution inspired by: https://gist.github.com/bennylope/1894706#gistcomment-2821633

---

Should help the handbook rank higher in search results more quickly.

If this approach looks good, I can look into other pages where this would be useful.

If you want to see it in action, I published the included page here: https://jblz.github.io/docs-v2/extending/adding/

Cheers!